### PR TITLE
Fix issue when channel number isn't an int (2.1, 2.2, etc)

### DIFF
--- a/Jellyfin.Plugin.TvHeadendApi/JsonConverters/IntToStringConverter.cs
+++ b/Jellyfin.Plugin.TvHeadendApi/JsonConverters/IntToStringConverter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.TvHeadendApi.JsonConverters;
+
+/// <summary>
+/// A custom converter for deserializing JSON properties that can be either an integer or a string into a C# string.
+/// </summary>
+public class IntToStringConverter : JsonConverter<string>
+{
+    /// <summary>
+    /// Reads and converts the JSON value.
+    /// </summary>
+    /// <param name="reader">The reader to read from.</param>
+    /// <param name="typeToConvert">The type of the object to convert.</param>
+    /// <param name="options">An object that specifies the serialization options to use.</param>
+    /// <returns>The converted string value.</returns>
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            // If the JSON token is a number, read it as a long and convert it to a string.
+            return reader.GetInt64().ToString(CultureInfo.InvariantCulture);
+        }
+        else if (reader.TokenType == JsonTokenType.String)
+        {
+            // If the JSON token is a string, read the string directly.
+            return reader.GetString() ?? string.Empty;
+        }
+        else
+        {
+            throw new JsonException($"Unexpected token type: {reader.TokenType}");
+        }
+    }
+
+    /// <summary>
+    /// Writes a specified string value as JSON.
+    /// </summary>
+    /// <param name="writer">The writer to write to.</param>
+    /// <param name="value">The value to convert to JSON.</param>
+    /// <param name="options">An object that specifies the serialization options to use.</param>
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        // When serializing, simply write the string value.
+        writer.WriteStringValue(value);
+    }
+}

--- a/Jellyfin.Plugin.TvHeadendApi/Model/TvhApiChannelGridEntry.cs
+++ b/Jellyfin.Plugin.TvHeadendApi/Model/TvhApiChannelGridEntry.cs
@@ -29,7 +29,7 @@ public class TvhApiChannelGridEntry
     /// This number is used to sort and access the channel in a TV guide or user interface.
     /// Example: 101.
     /// </summary>
-    public int Number { get; init; }
+    public string Number { get; init; } = string.Empty;
 
     /// <summary>
     /// Gets the URL to the channel's icon image.

--- a/Jellyfin.Plugin.TvHeadendApi/Model/TvhApiEpgEventsGridEntry.cs
+++ b/Jellyfin.Plugin.TvHeadendApi/Model/TvhApiEpgEventsGridEntry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Jellyfin.Plugin.TvHeadendApi.JsonConverters;
 
 namespace Jellyfin.Plugin.TvHeadendApi.Model;
 

--- a/Jellyfin.Plugin.TvHeadendApi/Service/LiveTvService.cs
+++ b/Jellyfin.Plugin.TvHeadendApi/Service/LiveTvService.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Plugin.TvHeadendApi.Configuration;
+using Jellyfin.Plugin.TvHeadendApi.JsonConverters;
 using Jellyfin.Plugin.TvHeadendApi.Model;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.Dto;
@@ -174,6 +174,8 @@ public sealed class LiveTvService : ILiveTvService, IDisposable
         };
 
         _httpClient = new HttpClient(handler);
+
+        JsonOptions.Converters.Add(new IntToStringConverter());
     }
 
     /// <summary>
@@ -347,7 +349,7 @@ public sealed class LiveTvService : ILiveTvService, IDisposable
                 {
                     Id = channel.Uuid, // Unique identifier for the channel
                     Name = channel.Name, // Display name of the channel
-                    Number = channel.Number.ToString(CultureInfo.InvariantCulture), // Logical number of the channel
+                    Number = channel.Number, // Logical number of the channel
                     ImageUrl = !string.IsNullOrWhiteSpace(channel.IconPublicUrl)
                         ? ConstructUrl(channel.IconPublicUrl.TrimStart('/'), "parameter")
                         : null, // URL to the channel's icon image


### PR DESCRIPTION
I have a setup where my channel numbers are 2.1 as well as including 110. So, the json that gets returned has the 110 as a number type and the 2.1 as a string. So, we need to handle both json types in a converter when reading the channel number due to how the tvheadend api returns the json types.